### PR TITLE
Add mastodon to bullet list

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Currently includes shortcodes for the following:
 * Twitter
 * Vimeo
 * Youtube
+* Mastodon
 
 ## Installation
 


### PR DESCRIPTION
Took me a while to figure out that Mastodon was an option because it was missing from the list at the top of the README